### PR TITLE
fix:fix path of zd in GetExeDir method

### DIFF
--- a/src/utils/file/file.go
+++ b/src/utils/file/file.go
@@ -148,9 +148,9 @@ func GetExeDir() string { // where zd.exe file in
 		}
 	} else { // debug
 		dir, _ = os.Getwd()
-		if commonUtils.IsMac() {
-			dir = "/Users/aaron/rd/project/zentao/go/zd"
-		}
+		//if commonUtils.IsMac() {
+		//	dir = "/Users/aaron/rd/project/zentao/go/zd"
+		//}
 	}
 
 	dir, _ = filepath.Abs(dir)


### PR DESCRIPTION
运行"go run src/zd.go -c demo/t.yaml"出现"... is not a vaild ZenData dir."错误.
由config.go文件的InitConfig方法报错，是因为当在mac平台上，file.go文件的路径是写死的。
对于不同的用户来说，路径肯定是不一样的，所以这里将写死的路径去掉，改为自动获取路径更为合适。